### PR TITLE
Use DocumentFragment for table rows

### DIFF
--- a/visor.html
+++ b/visor.html
@@ -142,6 +142,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Filas fijas
     tbody.innerHTML = '';
+    const frag = document.createDocumentFragment();
     for (let i = 1; i <= ROWS; i++) {
       const id = '#' + String(i).padStart(2, '0');
       const tr = document.createElement('tr');
@@ -157,8 +158,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const td1 = document.createElement('td'); td1.dataset.col = `Pozo${p}`; tr.appendChild(td1);
         const td2 = document.createElement('td'); td2.dataset.col = `Estado${p}`; tr.appendChild(td2);
       }
-      tbody.appendChild(tr);
+      frag.appendChild(tr);
     }
+    tbody.appendChild(frag);
   }
 
   // ---------- funciones nuevas ----------


### PR DESCRIPTION
## Summary
- use a DocumentFragment to build table rows before appending to tbody

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ace1dc3978832587199504a917e18f